### PR TITLE
document that latest version is the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add it as a step to your workflow
 
 ## Versions
 
-Specify a version
+Specify a version (defaults to the latest)
 
 ```yml
     - uses: ankane/setup-postgres@v1


### PR DESCRIPTION
Add a little note that the latest postgres version is the default, like in e.g. https://github.com/ankane/setup-elasticsearch#versions