### PR TITLE
Allow multiple databases to be created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Create a database
           database: testdb
 ```
 
+... or multiple databases:
+
+```yml
+      - uses: ankane/setup-postgres@v1
+        with:
+          database: |
+            testdb
+            testdb2
+```
+
 Set `postgresql.conf` config
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   config:
     description: Set config
   database:
-    description: Database to create
+    description: Database(s) to create
   dev-files:
     description: Install development files
 runs:

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ if (![15, 14, 13, 12, 11, 10, 9.6].includes(postgresVersion)) {
   throw `Postgres version not supported: ${postgresVersion}`;
 }
 
-const database = process.env['INPUT_DATABASE'];
+const databases = process.env['INPUT_DATABASE'];
 
 let bin;
 
@@ -140,8 +140,18 @@ if (isMac()) {
   bin = `/usr/lib/postgresql/${postgresVersion}/bin`;
 }
 
-if (database) {
-  runSafe(path.join(bin, "createdb"), database);
+if (databases) {
+  // Allow for database list, eg.
+  // with:
+  //   database: |
+  //     example_1
+  //     example_2
+  for (let db of databases.split(/[ \n]/)) {
+    db = db.trim();
+    if (db) {
+      runSafe(path.join(bin, "createdb"), db);
+    }
+  }
 }
 
 addToPath(bin);


### PR DESCRIPTION
eg. via something like:
```yml
      - uses: ankane/setup-postgres@v1
        with:
          database: |
            testdb
            testdb2
```

### Context

I have a singular test run that needs a couple of separate databases created (as in, the test suite uses two databases in its test run).

Unfortunately, running the action twice with different databases results in a failing `createdb` call, as the user already exists.

I first had a go at making it fail gracefully if the user already exists, but ran into problems, and then realised that it would probably be more efficient (given the setup that the action does) to just allow creating multiple databases at once.