### PR TITLE
Add PostGIS support for Linux Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,41 @@ Install development files (for building extensions)
           dev-files: true
 ```
 
+Install PostGIS extension (Linux Ubuntu only)
+
+```yml
+      - uses: ankane/setup-postgres@v1
+        with:
+          postgis: true
+```
+
+To enable the PostGIS extension in your database:
+
+```yml
+      - uses: ankane/setup-postgres@v1
+        with:
+          database: testdb
+          postgis: true
+      - run: psql -d testdb -c 'CREATE EXTENSION postgis;'
+```
+
+Example with custom configuration (note: `postgis` is NOT in shared_preload_libraries):
+
+```yml
+      - uses: ankane/setup-postgres@v1
+        with:
+          database: testdb
+          postgis: true
+          config: |
+            shared_preload_libraries = 'pg_stat_statements'
+            max_connections = 200
+      - run: psql -d testdb -c 'CREATE EXTENSION postgis;'
+```
+
+**Note:** PostGIS is only supported on Linux Ubuntu. The action automatically installs the appropriate PostGIS 3 version based on your PostgreSQL version.
+
+**Important:** Do not include `postgis` in `shared_preload_libraries` configuration. PostGIS is loaded as a database extension, not as a shared preload library.
+
 ## Extra Steps
 
 Run queries

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,8 @@ inputs:
     description: Database to create
   dev-files:
     description: Install development files
+  postgis:
+    description: Install PostGIS extension (Linux Ubuntu only)
 runs:
   using: node20
   main: index.js

--- a/index.js
+++ b/index.js
@@ -141,9 +141,11 @@ if (isMac()) {
     run(`echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg${snapshot} main${suffix}" | sudo tee /etc/apt/sources.list.d/pgdg.list`);
   }
 
-  if (postgresVersion != defaultVersion || isArm()) {
+  const postgis = process.env['INPUT_POSTGIS'];
+  
+  if (postgresVersion != defaultVersion || isArm() || postgis == 'true') {
     // remove previous cluster so port 5432 is used
-    if (!isArm()) {
+    if (!isArm() && postgresVersion != defaultVersion) {
       run(`sudo pg_dropcluster ${defaultVersion} main`);
 
       if (postgresVersion < defaultVersion) {
@@ -161,6 +163,12 @@ if (isMac()) {
   if (devFiles == 'true') {
     run(`sudo apt-get update`);
     run(`sudo apt-get install postgresql-server-dev-${postgresVersion}`);
+  }
+
+  // maybe support other truthy values in future
+  if (postgis == 'true') {
+    run(`sudo apt-get update`);
+    run(`sudo apt-get install postgresql-${postgresVersion}-postgis-3`);
   }
 
   const dataDir = `/etc/postgresql/${postgresVersion}/main`;


### PR DESCRIPTION
This PR adds PostGIS extension support to the setup-postgres action, enabling users to easily install PostGIS alongside PostgreSQL in their GitHub Actions workflows.

## Features Added

- **New `postgis` input**: Simple boolean flag to enable PostGIS installation
- **Linux Ubuntu only**: PostGIS support is limited to Linux Ubuntu runners (clearly documented)
- **PostGIS 3 installation**: Installs `postgresql-${version}-postgis-3` package for all supported PostgreSQL versions
- **Non-intrusive**: Does not automatically create PostGIS extensions, leaving that to user workflows

## Usage Example

```yml
- uses: ankane/setup-postgres@v1
  with:
    database: testdb
    postgis: true
- run: psql -d testdb -c 'CREATE EXTENSION postgis;'
```

## Changes Made

- Added `postgis` input to `action.yml`
- Integrated PostGIS installation into existing Linux workflow using `apt-get install postgresql-${postgresVersion}-postgis-3`
- Updated README with usage examples, compatibility notes, and important configuration guidance
- PostGIS installation triggers cluster recreation to ensure clean setup
- Maintains full backward compatibility

## Implementation Details

- PostGIS installation is handled by installing the `postgresql-${version}-postgis-3` package
- The installation occurs when `postgis: true` is set, which also triggers PostgreSQL cluster recreation
- Clear documentation warns against including `postgis` in `shared_preload_libraries` configuration
- Provides examples for both simple usage and custom configuration scenarios

## Testing

- [x] Follows existing code patterns and style
- [x] No breaking changes to existing functionality
- [x] Clear documentation and examples provided
- [x] Proper platform restrictions documented

Closes https://github.com/ankane/setup-postgres/issues/12